### PR TITLE
dont redirect error stream when running usercode

### DIFF
--- a/server/judge_client.py
+++ b/server/judge_client.py
@@ -125,10 +125,10 @@ class JudgeClient(object):
             user_output_file = os.path.join(user_output_dir, self._io_mode["output"])
             real_user_output_file = os.path.join(user_output_dir, "stdio.txt")
             shutil.copyfile(in_file, os.path.join(user_output_dir, self._io_mode["input"]))
-            kwargs = {"input_path": in_file, "output_path": real_user_output_file, "error_path": real_user_output_file}
+            kwargs = {"input_path": in_file, "output_path": real_user_output_file}
         else:
             real_user_output_file = user_output_file = os.path.join(self._submission_dir, test_case_file_id + ".out")
-            kwargs = {"input_path": in_file, "output_path": real_user_output_file, "error_path": real_user_output_file}
+            kwargs = {"input_path": in_file, "output_path": real_user_output_file}
 
         command = self._run_config["command"].format(exe_path=self._exe_path, exe_dir=os.path.dirname(self._exe_path),
                                                      max_memory=int(self._max_memory / 1024)).split(" ")


### PR DESCRIPTION
When runs java17 with current parameter. it prints

> WARNING: A command line option has enabled the Security Manager
WARNING: The Security Manager is deprecated and will be removed in a future release

in error std stream, which causes judge mistake.

This is a easy fix for any runtime warning.